### PR TITLE
Add methods to get mutable access to the contents.

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -63,6 +63,16 @@ impl<K: Eq + Hash, V: StableDeref> FrozenMap<K, V> {
         self.map.into_inner()
     }
 
+    /// Get mutable access to the underlying [`HashMap`].
+    ///
+    /// This is safe, as it requires a `&mut self`, ensuring nothing is using
+    /// the 'frozen' contents.
+    pub fn as_mut(&mut self) -> &mut HashMap<K, V> {
+        unsafe {
+            &mut *self.map.get()
+        }
+    }
+
     // TODO add more
 }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -63,6 +63,17 @@ impl<T: StableDeref> FrozenVec<T> {
     pub fn into_vec(self) -> Vec<T> {
         self.vec.into_inner()
     }
+
+    /// Get mutable access to the underlying vector.
+    ///
+    /// This is safe, as it requires a `&mut self`, ensuring nothing is using
+    /// the 'frozen' contents.
+    pub fn as_mut(&mut self) -> &mut Vec<T> {
+        unsafe {
+            &mut *self.vec.get()
+        }
+    }
+
     // TODO add more
 }
 


### PR DESCRIPTION
Not sure about the names for these methods. Could be `as_mut`, `as_mut_vec`, `as_vec`, `unfreeze`, `melt`, `let_it_go`, `access_mut`, ...

I think the one for the `Vec` could even be exposed through `DerefMut`.