### PR TITLE
Added a way to safely use the smart pointers in FrozenMap

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -91,7 +91,7 @@ impl<K: Eq + Hash, V: StableDeref> FrozenMap<K, V> {
     /// assert_eq!(map.map_get(&1, Clone::clone), Some(Box::new("a")));
     /// assert_eq!(map.map_get(&2, Clone::clone), None);
     /// ```
-    pub fn map_get<Q: ?Sized, T, F>(&self, k:&Q, f: F) -> Option<T> 
+    pub fn map_get<Q: ?Sized, T, F>(&self, k: &Q, f: F) -> Option<T> 
     where
         K: Borrow<Q>,
         Q: Hash + Eq,

--- a/src/map.rs
+++ b/src/map.rs
@@ -44,6 +44,22 @@ impl<K: Eq + Hash, V: StableDeref> FrozenMap<K, V> {
         ret
     }
 
+    /// Applies a function to the owner of the value corresponding to the key (if any).
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use elsa::FrozenMap;
+    ///
+    /// let map = FrozenMap::new();
+    /// map.insert(1, Box::new("a"));
+    /// assert_eq!(map.map_get(&1, Clone::clone), Some(Box::new("a")));
+    /// assert_eq!(map.map_get(&2, Clone::clone), None);
+    /// ```
     pub fn map_get<Q:?Sized, T, F>(&self, k:&Q, f:F) -> Option<T> 
     where
         K: Borrow<Q>,
@@ -60,6 +76,22 @@ impl<K: Eq + Hash, V: StableDeref> FrozenMap<K, V> {
         ret
     }
 
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use elsa::FrozenMap;
+    ///
+    /// let map = FrozenMap::new();
+    /// map.insert(1, Box::new("a"));
+    /// assert_eq!(map.get(&1), Some(&"a"));
+    /// assert_eq!(map.get(&2), None);
+    /// ```
     pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V::Target>
     where
         K: Borrow<Q>,


### PR DESCRIPTION
# what

i added a `fn map_get<T,F:FnOnce(&V) ->T>(&self, &K, F) -> Option<T>` function, which lets you use a `&V` (smart pointer reference) inside the lock where it's safe to do so

also re-implemented `get` in terms of `map_get`

# why

i wanted to be able to clone a `Rc<T>` from a `FrozenMap<K, Rc<T>>` sometimes

# alternatives

- `fn get_clone(&self, &K) -> V where V:Clone`
- `fn get_locked(&self, &K) -> Ref<V>`

`get_clone` is more limited. `get_locked` is more cumbersome to implement

if this goes in (or gets the 👍 ), i can do the rest of the collections