### PR TITLE
added map_get for sync::FrozenMap and FrozenIndexMap

### DIFF
--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -59,6 +59,22 @@ impl<K: Eq + Hash, V: StableDeref> FrozenIndexMap<K, V> {
         ret
     }
 
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use elsa::FrozenIndexMap;
+    ///
+    /// let map = FrozenIndexMap::new();
+    /// map.insert(1, Box::new("a"));
+    /// assert_eq!(map.get(&1), Some(&"a"));
+    /// assert_eq!(map.get(&2), None);
+    /// ```
     pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V::Target>
     where
         K: Borrow<Q>,
@@ -69,6 +85,38 @@ impl<K: Eq + Hash, V: StableDeref> FrozenIndexMap<K, V> {
         let ret = unsafe {
             let map = self.map.get();
             (*map).get(k).map(|x| &**x)
+        };
+        self.in_use.set(false);
+        ret
+    }
+
+    /// Applies a function to the owner of the value corresponding to the key (if any).
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use elsa::FrozenIndexMap;
+    ///
+    /// let map = FrozenIndexMap::new();
+    /// map.insert(1, Box::new("a"));
+    /// assert_eq!(map.map_get(&1, Clone::clone), Some(Box::new("a")));
+    /// assert_eq!(map.map_get(&2, Clone::clone), None);
+    /// ```
+    pub fn map_get<Q: ?Sized, T, F>(&self, k: &Q, f: F) -> Option<T>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+        F: FnOnce(&V) -> T,
+    {
+        assert!(!self.in_use.get());
+        self.in_use.set(true);
+        let ret = unsafe {
+            let map = self.map.get();
+            (*map).get(k).map(f)
         };
         self.in_use.set(false);
         ret

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -39,6 +39,22 @@ impl<K: Eq + Hash, V: StableDeref> FrozenMap<K, V> {
         ret
     }
 
+    /// Returns a reference to the value corresponding to the key.
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use elsa::sync::FrozenMap;
+    ///
+    /// let map = FrozenMap::new();
+    /// map.insert(1, Box::new("a"));
+    /// assert_eq!(map.get(&1), Some(&"a"));
+    /// assert_eq!(map.get(&2), None);
+    /// ```
     pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V::Target>
     where
         K: Borrow<Q>,
@@ -46,6 +62,33 @@ impl<K: Eq + Hash, V: StableDeref> FrozenMap<K, V> {
     {
         let map = self.map.read().unwrap();
         let ret = unsafe { map.get(k).map(|x| &*(&**x as *const V::Target)) };
+        ret
+    }
+
+    /// Applies a function to the owner of the value corresponding to the key (if any).
+    ///
+    /// The key may be any borrowed form of the map's key type, but
+    /// [`Hash`] and [`Eq`] on the borrowed form *must* match those for
+    /// the key type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use elsa::sync::FrozenMap;
+    ///
+    /// let map = FrozenMap::new();
+    /// map.insert(1, Box::new("a"));
+    /// assert_eq!(map.map_get(&1, Clone::clone), Some(Box::new("a")));
+    /// assert_eq!(map.map_get(&2, Clone::clone), None);
+    /// ```
+    pub fn map_get<Q: ?Sized, T, F>(&self, k: &Q, f: F) -> Option<T>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+        F: FnOnce(&V) -> T,
+    {
+        let map = self.map.read().unwrap();
+        let ret = map.get(k).map(f);
         ret
     }
 


### PR DESCRIPTION
i didn't implement it for FrozenIndexSet, because i'm not really sure how that struct is intended to be used

and i didn't add it to FrozenVec, because FrozenVec doesn't have a `in_use` flag, and it would be unsafe to run an arbitrary function without that