### PR TITLE
Add more functions to FrozenVec

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -54,6 +54,10 @@ impl<T: StableDeref> FrozenVec<T> {
     }
 
     /// Returns a reference to an element, without doing bounds checking.
+    ///
+    /// ## Safety
+    ///
+    /// `index` must be in bounds, i.e. it must be less than `self.len()`
     pub unsafe fn get_unchecked(&self, index: usize) -> &T::Target {
         let vec = self.vec.get();
         &**(*vec).get_unchecked(index)

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -15,6 +15,7 @@ pub struct FrozenVec<T> {
 // safety: UnsafeCell implies !Sync
 
 impl<T> FrozenVec<T> {
+    /// Constructs a new, empty vector.
     pub fn new() -> Self {
         Self {
             vec: UnsafeCell::new(Default::default()),
@@ -26,6 +27,7 @@ impl<T: StableDeref> FrozenVec<T> {
     // these should never return &T
     // these should never delete any entries
 
+    /// Appends an element to the back of the vector.
     pub fn push(&self, val: T) {
         unsafe {
             let vec = self.vec.get();
@@ -42,6 +44,7 @@ impl<T: StableDeref> FrozenVec<T> {
         }
     }
 
+    /// Returns a reference to an element.
     pub fn get(&self, index: usize) -> Option<&T::Target> {
         unsafe {
             let vec = self.vec.get();
@@ -49,6 +52,7 @@ impl<T: StableDeref> FrozenVec<T> {
         }
     }
 
+    /// Returns the number of elements in the vector.
     pub fn len(&self) -> usize {
         unsafe {
             let vec = self.vec.get();
@@ -56,10 +60,33 @@ impl<T: StableDeref> FrozenVec<T> {
         }
     }
 
+    /// Returns `true` if the vector contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns the first element of the vector, or `None` if empty.
+    pub fn first(&self) -> Option<&T::Target> {
+        unsafe {
+            let vec = self.vec.get();
+            (*vec).first().map(|x| &**x)
+        }
+    }
+
+    /// Returns the last element of the vector, or `None` if empty.
+    pub fn last(&self) -> Option<&T::Target> {
+        unsafe {
+            let vec = self.vec.get();
+            (*vec).last().map(|x| &**x)
+        }
+    }
+
+    /// Returns an iterator over the vector.
     pub fn iter(&self) -> Iter<T> {
         self.into_iter()
     }
 
+    /// Converts the frozen vector into a plain vector.
     pub fn into_vec(self) -> Vec<T> {
         self.vec.into_inner()
     }
@@ -151,4 +178,25 @@ fn test_iteration() {
     }
 
     assert_eq!(vec.len(), frozen.iter().count())
+}
+
+#[test]
+fn test_accessors() {
+    let vec: FrozenVec<String> = FrozenVec::new();
+
+    assert_eq!(vec.is_empty(), true);
+    assert_eq!(vec.len(), 0);
+    assert_eq!(vec.first(), None);
+    assert_eq!(vec.last(), None);
+    assert_eq!(vec.get(1), None);
+
+    vec.push("a".to_string());
+    vec.push("b".to_string());
+    vec.push("c".to_string());
+
+    assert_eq!(vec.is_empty(), false);
+    assert_eq!(vec.len(), 3);
+    assert_eq!(vec.first(), Some("a"));
+    assert_eq!(vec.last(), Some("c"));
+    assert_eq!(vec.get(1), Some("b"));
 }


### PR DESCRIPTION
These have the obvious functionality corresponding to their slice equivalents.

As for the binary search functions — these are, unfortunately, a copy-paste from `core`, since we cannot safely call the underlying slice functions without some kind of reentrancy protection (user callbacks are involved that could push to the vector).