### PR TITLE
Implement `std::convert::AsMut` instead of "custom" `as_mut` functions

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -53,6 +53,16 @@ impl<K: Eq + Hash, V> FrozenMap<K, V> {
     }
 }
 
+impl<K, V, S> std::convert::AsMut<HashMap<K, V, S>> for FrozenMap<K, V, S> {
+    /// Get mutable access to the underlying [`HashMap`].
+    ///
+    /// This is safe, as it requires a `&mut self`, ensuring nothing is using
+    /// the 'frozen' contents.
+    fn as_mut(&mut self) -> &mut HashMap<K, V, S> {
+        unsafe { &mut *self.map.get() }
+    }
+}
+
 impl<K: Eq + Hash, V: StableDeref, S: BuildHasher> FrozenMap<K, V, S> {
     // these should never return &K or &V
     // these should never delete any entries
@@ -132,14 +142,6 @@ impl<K: Eq + Hash, V: StableDeref, S: BuildHasher> FrozenMap<K, V, S> {
 
     pub fn into_map(self) -> HashMap<K, V, S> {
         self.map.into_inner()
-    }
-
-    /// Get mutable access to the underlying [`HashMap`].
-    ///
-    /// This is safe, as it requires a `&mut self`, ensuring nothing is using
-    /// the 'frozen' contents.
-    pub fn as_mut(&mut self) -> &mut HashMap<K, V, S> {
-        unsafe { &mut *self.map.get() }
     }
 
     // TODO add more
@@ -275,6 +277,16 @@ impl<K: Clone + Ord, V: StableDeref> FrozenBTreeMap<K, V> {
     }
 }
 
+impl<K, V> std::convert::AsMut<BTreeMap<K, V>> for FrozenBTreeMap<K, V> {
+    /// Get mutable access to the underlying [`HashMap`].
+    ///
+    /// This is safe, as it requires a `&mut self`, ensuring nothing is using
+    /// the 'frozen' contents.
+    fn as_mut(&mut self) -> &mut BTreeMap<K, V> {
+        unsafe { &mut *self.map.get() }
+    }
+}
+
 impl<K: Clone + Ord, V: StableDeref> FrozenBTreeMap<K, V> {
     // these should never return &K or &V
     // these should never delete any entries
@@ -354,14 +366,6 @@ impl<K: Clone + Ord, V: StableDeref> FrozenBTreeMap<K, V> {
 
     pub fn into_map(self) -> BTreeMap<K, V> {
         self.map.into_inner()
-    }
-
-    /// Get mutable access to the underlying [`HashMap`].
-    ///
-    /// This is safe, as it requires a `&mut self`, ensuring nothing is using
-    /// the 'frozen' contents.
-    pub fn as_mut(&mut self) -> &mut BTreeMap<K, V> {
-        unsafe { &mut *self.map.get() }
     }
 
     // TODO add more

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -24,6 +24,16 @@ impl<T> FrozenVec<T> {
     }
 }
 
+impl<T> std::convert::AsMut<Vec<T>> for FrozenVec<T> {
+    /// Get mutable access to the underlying vector.
+    ///
+    /// This is safe, as it requires a `&mut self`, ensuring nothing is using
+    /// the 'frozen' contents.
+    fn as_mut(&mut self) -> &mut Vec<T> {
+        unsafe { &mut *self.vec.get() }
+    }
+}
+
 impl<T: StableDeref> FrozenVec<T> {
     // these should never return &T
     // these should never delete any entries
@@ -100,14 +110,6 @@ impl<T: StableDeref> FrozenVec<T> {
     /// Converts the frozen vector into a plain vector.
     pub fn into_vec(self) -> Vec<T> {
         self.vec.into_inner()
-    }
-
-    /// Get mutable access to the underlying vector.
-    ///
-    /// This is safe, as it requires a `&mut self`, ensuring nothing is using
-    /// the 'frozen' contents.
-    pub fn as_mut(&mut self) -> &mut Vec<T> {
-        unsafe { &mut *self.vec.get() }
     }
 
     // binary search functions: they need to be reimplemented here to be safe (instead of calling


### PR DESCRIPTION
This is per a clippy suggestion but seems like a good idea. I think the `StableDeref` trait is not required here since the reference is guaranteed-unique.