### PR TITLE
Extend `sync::FrozenVec` and `sync::FrozenMap`

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -277,6 +277,7 @@ impl<K: Eq + Hash, V: Copy> FrozenMap<K, V> {
     /// ```
     pub fn get_copy_or_insert(&self, k: K, v: V) -> V {
         let mut map = self.map.write().unwrap();
+        // This is safe because `or_insert` does not overwrite existing values
         let inserted = map.entry(k).or_insert(v);
         *inserted
     }
@@ -306,6 +307,7 @@ impl<K: Eq + Hash, V: Copy> FrozenMap<K, V> {
     /// ```
     pub fn get_copy_or_insert_with(&self, k: K, f: impl FnOnce() -> V) -> V {
         let mut map = self.map.write().unwrap();
+        // This is safe because `or_insert_with` does not overwrite existing values
         let inserted = map.entry(k).or_insert_with(f);
         *inserted
     }
@@ -335,6 +337,7 @@ impl<K: Eq + Hash, V: Copy> FrozenMap<K, V> {
     /// ```
     pub fn get_copy_or_insert_with_key(&self, k: K, f: impl FnOnce(&K) -> V) -> V {
         let mut map = self.map.write().unwrap();
+        // This is safe because `or_insert_with_key` does not overwrite existing values
         let inserted = map.entry(k).or_insert_with_key(f);
         *inserted
     }


### PR DESCRIPTION
`FrozenVec`:
- `len` and `is_empty`
- Implement `AsMut` to allow exclusive references to pass through

`FrozenMap`:
- Generalized `new` to remove type constraints
- `keys_cloned` to replace `keys` in the absence of safe iterators or references to keys
- Several functions operating on `V` by value when `V: Copy`
  - `get_copy`
  - `get_copy_or_insert`, `get_copy_or_insert_with`, `get_copy_or_insert_with_key`, analogs to the corresponding non-`get_copy` methods
 - Implement `AsMut` to allow exclusive references to pass through