### PR TITLE
Fix integer overflow -> undefined behavior in LockFreeFrozenVec capacity

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -504,9 +504,7 @@ impl<T: Copy> LockFreeFrozenVec<T> {
     }
 
     fn layout(cap: usize) -> Layout {
-        let num_bytes = std::mem::size_of::<T>() * cap;
-        let align = std::mem::align_of::<T>();
-        Layout::from_size_align(num_bytes, align).unwrap()
+        Layout::array::<T>(cap).unwrap()
     }
 
     // these should never return &T


### PR DESCRIPTION
The following example currently overflows `usize` in the calculation of the allocation size, writes into an allocation that is actually zero bytes, and segfaults:

```rust
use elsa::sync::*;

fn main() {
    let v = LockFreeFrozenVec::<u64>::with_capacity(1<<(64 - 3));
    loop { v.push(1); }
}
```

This changes it to use `Layout::array`, which checks for overflow.