### PR TITLE
Implement IntoIterator for everything

### DIFF
--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -136,6 +136,28 @@ impl<K: Eq + Hash, V: StableDeref, S: BuildHasher> FrozenIndexMap<K, V, S> {
         self.in_use.set(false);
         ret
     }
+}
+
+impl<K, V, S> FrozenIndexMap<K, V, S> {
+    /// Collects the contents of this map into a vector of tuples.
+    ///
+    /// The order of the entries is as if iterating an [`IndexMap`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use elsa::FrozenIndexMap;
+    ///
+    /// let map = FrozenIndexMap::new();
+    /// map.insert(1, Box::new("a"));
+    /// map.insert(2, Box::new("b"));
+    /// let tuple_vec = map.into_tuple_vec();
+    ///
+    /// assert_eq!(tuple_vec, vec![(1, Box::new("a")), (2, Box::new("b"))]);
+    /// ```
+    pub fn into_tuple_vec(self) -> Vec<(K, V)> {
+        self.map.into_inner().into_iter().collect::<Vec<_>>()
+    }
 
     pub fn into_map(self) -> IndexMap<K, V, S> {
         self.map.into_inner()
@@ -211,18 +233,5 @@ impl<K: Eq + Hash, V, S: Default> Default for FrozenIndexMap<K, V, S> {
             map: UnsafeCell::new(Default::default()),
             in_use: Cell::new(false),
         }
-    }
-}
-
-impl<K, V, S> IntoIterator for FrozenIndexMap<K, V, S> {
-    type Item = (K, V);
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.map
-            .into_inner()
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_iter()
     }
 }

--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -172,11 +172,11 @@ impl<K, V, S> From<IndexMap<K, V, S>> for FrozenIndexMap<K, V, S> {
 }
 
 impl<Q: ?Sized, K: Eq + Hash, V: StableDeref, S: BuildHasher> Index<&Q> for FrozenIndexMap<K, V, S>
-    where
-        Q: Eq + Hash,
-        K: Eq + Hash + Borrow<Q>,
-        V: StableDeref,
-        S: BuildHasher
+where
+    Q: Eq + Hash,
+    K: Eq + Hash + Borrow<Q>,
+    V: StableDeref,
+    S: BuildHasher,
 {
     type Output = V::Target;
 
@@ -211,5 +211,18 @@ impl<K: Eq + Hash, V, S: Default> Default for FrozenIndexMap<K, V, S> {
             map: UnsafeCell::new(Default::default()),
             in_use: Cell::new(false),
         }
+    }
+}
+
+impl<K, V, S> IntoIterator for FrozenIndexMap<K, V, S> {
+    type Item = (K, V);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map
+            .into_inner()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 }

--- a/src/index_set.rs
+++ b/src/index_set.rs
@@ -124,7 +124,9 @@ impl<T: Eq + Hash + StableDeref, S: BuildHasher> FrozenIndexSet<T, S> {
         self.in_use.set(false);
         ret
     }
+}
 
+impl<T, S> FrozenIndexSet<T, S> {
     pub fn into_set(self) -> IndexSet<T, S> {
         self.set.into_inner()
     }
@@ -176,18 +178,5 @@ impl<T: Eq + Hash, S: Default + BuildHasher> FromIterator<T> for FrozenIndexSet<
 impl<T: Eq + Hash, S: Default> Default for FrozenIndexSet<T, S> {
     fn default() -> Self {
         Self::from(IndexSet::default())
-    }
-}
-
-impl<T, S> IntoIterator for FrozenIndexSet<T, S> {
-    type Item = T;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.set
-            .into_inner()
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_iter()
     }
 }

--- a/src/index_set.rs
+++ b/src/index_set.rs
@@ -178,3 +178,16 @@ impl<T: Eq + Hash, S: Default> Default for FrozenIndexSet<T, S> {
         Self::from(IndexSet::default())
     }
 }
+
+impl<T, S> IntoIterator for FrozenIndexSet<T, S> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.set
+            .into_inner()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+}

--- a/src/map.rs
+++ b/src/map.rs
@@ -247,6 +247,19 @@ impl<K: Eq + Hash, V, S: Default> Default for FrozenMap<K, V, S> {
     }
 }
 
+impl<K, V> IntoIterator for FrozenMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map
+            .into_inner()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+}
+
 /// Append-only version of `std::collections::BTreeMap` where
 /// insertion does not require mutable access
 pub struct FrozenBTreeMap<K, V> {
@@ -447,5 +460,18 @@ impl<K: Clone + Ord, V: StableDeref> Default for FrozenBTreeMap<K, V> {
             map: UnsafeCell::new(Default::default()),
             in_use: Cell::new(false),
         }
+    }
+}
+
+impl<K, V> IntoIterator for FrozenBTreeMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map
+            .into_inner()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -143,6 +143,29 @@ impl<K: Eq + Hash, V: StableDeref, S: BuildHasher> FrozenMap<K, V, S> {
         self.in_use.set(false);
         ret
     }
+}
+
+impl<K, V, S> FrozenMap<K, V, S> {
+    /// Collects the contents of this map into a vector of tuples.
+    ///
+    /// The order of the entries is as if iterating a [`HashMap`] (stochastic).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use elsa::sync::FrozenMap;
+    ///
+    /// let map = FrozenMap::new();
+    /// map.insert(1, Box::new("a"));
+    /// map.insert(2, Box::new("b"));
+    /// let mut tuple_vec = map.into_tuple_vec();
+    /// tuple_vec.sort();
+    ///
+    /// assert_eq!(tuple_vec, vec![(1, Box::new("a")), (2, Box::new("b"))]);
+    /// ```
+    pub fn into_tuple_vec(self) -> Vec<(K, V)> {
+        self.map.into_inner().into_iter().collect::<Vec<_>>()
+    }
 
     pub fn into_map(self) -> HashMap<K, V, S> {
         self.map.into_inner()
@@ -244,19 +267,6 @@ impl<K: Eq + Hash, V, S: Default> Default for FrozenMap<K, V, S> {
             map: UnsafeCell::new(Default::default()),
             in_use: Cell::new(false),
         }
-    }
-}
-
-impl<K, V> IntoIterator for FrozenMap<K, V> {
-    type Item = (K, V);
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.map
-            .into_inner()
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_iter()
     }
 }
 
@@ -394,6 +404,29 @@ impl<K: Clone + Ord, V: StableDeref> FrozenBTreeMap<K, V> {
         self.in_use.set(false);
         ret
     }
+}
+
+impl<K, V> FrozenBTreeMap<K, V> {
+    /// Collects the contents of this map into a vector of tuples.
+    ///
+    /// The order of the entries is as if iterating a [`BTreeMap`] (ordered by key).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use elsa::sync::FrozenBTreeMap;
+    ///
+    /// let map = FrozenBTreeMap::new();
+    /// map.insert(1, Box::new("a"));
+    /// map.insert(2, Box::new("b"));
+    /// let mut tuple_vec = map.into_tuple_vec();
+    /// tuple_vec.sort();
+    ///
+    /// assert_eq!(tuple_vec, vec![(1, Box::new("a")), (2, Box::new("b"))]);
+    /// ```
+    pub fn into_tuple_vec(self) -> Vec<(K, V)> {
+        self.map.into_inner().into_iter().collect::<Vec<_>>()
+    }
 
     pub fn into_map(self) -> BTreeMap<K, V> {
         self.map.into_inner()
@@ -460,18 +493,5 @@ impl<K: Clone + Ord, V: StableDeref> Default for FrozenBTreeMap<K, V> {
             map: UnsafeCell::new(Default::default()),
             in_use: Cell::new(false),
         }
-    }
-}
-
-impl<K, V> IntoIterator for FrozenBTreeMap<K, V> {
-    type Item = (K, V);
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.map
-            .into_inner()
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_iter()
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -448,7 +448,7 @@ impl<T: StableDeref> FrozenVec<T> {
 }
 
 impl<T> FrozenVec<T> {
-    /// Collects the contents of this map into a normal vector.
+    /// Returns the internal vector backing this structure
     ///
     /// # Examples
     ///

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -353,6 +353,20 @@ impl<K, V> std::convert::AsMut<HashMap<K, V>> for FrozenMap<K, V> {
     }
 }
 
+impl<K, V> IntoIterator for FrozenMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.map
+            .into_inner()
+            .unwrap()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+}
+
 /// Append-only threadsafe version of `std::vec::Vec` where
 /// insertion does not require mutable access
 pub struct FrozenVec<T> {
@@ -437,6 +451,15 @@ impl<T> Default for FrozenVec<T> {
         Self {
             vec: Default::default(),
         }
+    }
+}
+
+impl<T> IntoIterator for FrozenVec<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vec.into_inner().unwrap().into_iter()
     }
 }
 
@@ -620,6 +643,8 @@ fn test_non_lockfree() {
     ] {}
 }
 
+// TODO: Implement IntoIterator for LockFreeFrozenVec
+
 /// Append-only threadsafe version of `std::collections::BTreeMap` where
 /// insertion does not require mutable access
 #[derive(Debug)]
@@ -779,5 +804,19 @@ impl<K: Clone + Ord, V: StableDeref> FromIterator<(K, V)> for FrozenBTreeMap<K, 
 impl<K: Clone + Ord, V: StableDeref> Default for FrozenBTreeMap<K, V> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<K, V> IntoIterator for FrozenBTreeMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0
+            .into_inner()
+            .unwrap()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_iter()
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -463,11 +463,7 @@ impl<T> FrozenVec<T> {
     /// assert_eq!(tuple_vec, vec!["a", "b"]);
     /// ```
     pub fn into_vec(self) -> Vec<T> {
-        self.vec
-            .into_inner()
-            .unwrap()
-            .into_iter()
-            .collect::<Vec<_>>()
+        self.vec.into_inner().unwrap()
     }
 
     // TODO add more

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -275,19 +275,6 @@ impl<'a, T: StableDeref> IntoIterator for &'a FrozenVec<T> {
     }
 }
 
-impl<T> IntoIterator for FrozenVec<T> {
-    type Item = T;
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.vec
-            .into_inner()
-            .into_iter()
-            .collect::<Vec<_>>()
-            .into_iter()
-    }
-}
-
 #[test]
 fn test_iteration() {
     let vec = vec!["a", "b", "c", "d"];

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -275,6 +275,19 @@ impl<'a, T: StableDeref> IntoIterator for &'a FrozenVec<T> {
     }
 }
 
+impl<T> IntoIterator for FrozenVec<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vec
+            .into_inner()
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+}
+
 #[test]
 fn test_iteration() {
     let vec = vec!["a", "b", "c", "d"];


### PR DESCRIPTION
I made the trait impls return a `std::vec::IntoIter` in order to decouple the iterator type from the inner type.