### PR TITLE
feat: add missing `#[derive(Debug)]` implementations

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -3,6 +3,7 @@ use std::cell::{Cell, UnsafeCell};
 use std::collections::hash_map::RandomState;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::convert::AsMut;
 use std::hash::{BuildHasher, Hash};
 use std::iter::FromIterator;
 use std::ops::Index;
@@ -11,6 +12,7 @@ use stable_deref_trait::StableDeref;
 
 /// Append-only version of `std::collections::HashMap` where
 /// insertion does not require mutable access
+#[derive(Debug)]
 pub struct FrozenMap<K, V, S = RandomState> {
     map: UnsafeCell<HashMap<K, V, S>>,
     /// Eq/Hash implementations can have side-effects, and using Rc it is possible
@@ -208,7 +210,7 @@ impl<K: Eq + Hash + StableDeref, V: StableDeref, S: BuildHasher> FrozenMap<K, V,
     }
 }
 
-impl<K, V, S> std::convert::AsMut<HashMap<K, V, S>> for FrozenMap<K, V, S> {
+impl<K, V, S> AsMut<HashMap<K, V, S>> for FrozenMap<K, V, S> {
     /// Get mutable access to the underlying [`HashMap`].
     ///
     /// This is safe, as it requires a `&mut self`, ensuring nothing is using
@@ -272,6 +274,7 @@ impl<K: Eq + Hash, V, S: Default> Default for FrozenMap<K, V, S> {
 
 /// Append-only version of `std::collections::BTreeMap` where
 /// insertion does not require mutable access
+#[derive(Debug)]
 pub struct FrozenBTreeMap<K, V> {
     map: UnsafeCell<BTreeMap<K, V>>,
     /// Eq/Hash implementations can have side-effects, and using Rc it is possible
@@ -435,7 +438,7 @@ impl<K, V> FrozenBTreeMap<K, V> {
     // TODO add more
 }
 
-impl<K, V> std::convert::AsMut<BTreeMap<K, V>> for FrozenBTreeMap<K, V> {
+impl<K, V> AsMut<BTreeMap<K, V>> for FrozenBTreeMap<K, V> {
     /// Get mutable access to the underlying [`HashMap`].
     ///
     /// This is safe, as it requires a `&mut self`, ensuring nothing is using

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -11,18 +11,20 @@ use std::alloc::Layout;
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::convert::AsMut;
 use std::hash::Hash;
 use std::iter::{FromIterator, IntoIterator};
 use std::ops::Index;
 
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicPtr;
-use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::AtomicUsize; 
 use std::sync::atomic::Ordering;
 use std::sync::RwLock;
 
 /// Append-only threadsafe version of `std::collections::HashMap` where
 /// insertion does not require mutable access
+#[derive(Debug)]
 pub struct FrozenMap<K, V> {
     map: RwLock<HashMap<K, V>>,
 }
@@ -371,7 +373,7 @@ impl<K: Eq + Hash, V: Copy> FrozenMap<K, V> {
     }
 }
 
-impl<K, V> std::convert::AsMut<HashMap<K, V>> for FrozenMap<K, V> {
+impl<K, V> AsMut<HashMap<K, V>> for FrozenMap<K, V> {
     /// Get mutable access to the underlying [`HashMap`].
     ///
     /// This is safe, as it requires a `&mut self`, ensuring nothing is using
@@ -383,6 +385,7 @@ impl<K, V> std::convert::AsMut<HashMap<K, V>> for FrozenMap<K, V> {
 
 /// Append-only threadsafe version of `std::vec::Vec` where
 /// insertion does not require mutable access
+#[derive(Debug)]
 pub struct FrozenVec<T> {
     vec: RwLock<Vec<T>>,
 }
@@ -470,7 +473,7 @@ impl<T> FrozenVec<T> {
     // TODO add more
 }
 
-impl<T> std::convert::AsMut<Vec<T>> for FrozenVec<T> {
+impl<T> AsMut<Vec<T>> for FrozenVec<T> {
     /// Get mutable access to the underlying vector.
     ///
     /// This is safe, as it requires a `&mut self`, ensuring nothing is using
@@ -539,6 +542,7 @@ const NUM_BUFFERS: usize = (usize::BITS >> 2) as usize;
 /// Note that this data structure is `64` pointers large on
 /// 64 bit systems,
 /// in contrast to `Vec` which is `3` pointers large.
+#[derive(Debug)]
 pub struct LockFreeFrozenVec<T: Copy> {
     data: [AtomicPtr<T>; NUM_BUFFERS],
     len: AtomicUsize,

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,5 +1,6 @@
 use std::cell::UnsafeCell;
 use std::cmp::Ordering;
+use std::convert::AsMut;
 use std::iter::FromIterator;
 use std::ops::Index;
 
@@ -7,6 +8,7 @@ use stable_deref_trait::StableDeref;
 
 /// Append-only version of `std::vec::Vec` where
 /// insertion does not require mutable access
+#[derive(Debug)]
 pub struct FrozenVec<T> {
     vec: UnsafeCell<Vec<T>>,
     // XXXManishearth do we need a reentrancy guard here as well?
@@ -108,7 +110,7 @@ impl<T: StableDeref> FrozenVec<T> {
         }
     }
     /// Returns an iterator over the vector.
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         self.into_iter()
     }
 }
@@ -200,7 +202,7 @@ impl<T: StableDeref> FrozenVec<T> {
     // TODO add more
 }
 
-impl<T> std::convert::AsMut<Vec<T>> for FrozenVec<T> {
+impl<T> AsMut<Vec<T>> for FrozenVec<T> {
     /// Get mutable access to the underlying vector.
     ///
     /// This is safe, as it requires a `&mut self`, ensuring nothing is using
@@ -250,6 +252,7 @@ impl<A> FromIterator<A> for FrozenVec<A> {
 /// Iterator over FrozenVec, obtained via `.iter()`
 ///
 /// It is safe to push to the vector during iteration
+#[derive(Debug)]
 pub struct Iter<'a, T> {
     vec: &'a FrozenVec<T>,
     idx: usize,


### PR DESCRIPTION
I've also switched a qualified `AsMut` to an `use` and exhibited an implicit lifetime on a return of `Iter<'a, T>`, with the assumption they would be welcome cleanup. Happy to revert any of those if wished.

Fixes #32.