### PR TITLE
Fixes for PartialEq for frozen map and vec

### DIFF
--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -308,7 +308,7 @@ impl<T: Hash + Eq, S: PartialEq> PartialEq for FrozenIndexMap<T, S> {
         assert!(!other.in_use.get());
         self.in_use.set(true);
         other.in_use.set(true);
-        let ret = unsafe { *self.map.get() == *other.map.get() };
+        let ret = unsafe { self.map.get().as_ref() == other.map.get().as_ref() };
         self.in_use.set(false);
         other.in_use.set(false);
         ret

--- a/src/index_set.rs
+++ b/src/index_set.rs
@@ -269,7 +269,7 @@ impl<T: Hash + Eq, S: BuildHasher> PartialEq for FrozenIndexSet<T, S> {
         assert!(!other.in_use.get());
         self.in_use.set(true);
         other.in_use.set(true);
-        let ret = unsafe { *self.set.get() == *other.set.get() };
+        let ret = unsafe { self.set.get().as_ref() == other.set.get().as_ref() };
         self.in_use.set(false);
         other.in_use.set(false);
         ret

--- a/src/map.rs
+++ b/src/map.rs
@@ -289,7 +289,7 @@ impl<K: Eq + Hash, V: PartialEq + StableDeref> PartialEq for FrozenMap<K, V> {
         assert!(!other.in_use.get());
         self.in_use.set(true);
         other.in_use.set(true);
-        let ret = self.map.get() == other.map.get();
+        let ret = unsafe { self.map.get().as_ref() == other.map.get().as_ref() };
         self.in_use.set(false);
         other.in_use.set(false);
         ret
@@ -541,7 +541,7 @@ impl<K: Eq + Hash, V: PartialEq + StableDeref> PartialEq for FrozenBTreeMap<K, V
         assert!(!other.in_use.get());
         self.in_use.set(true);
         other.in_use.set(true);
-        let ret = self.map.get() == other.map.get();
+        let ret = unsafe { self.map.get().as_ref() == other.map.get().as_ref() };
         self.in_use.set(false);
         other.in_use.set(false);
         ret

--- a/src/map.rs
+++ b/src/map.rs
@@ -283,6 +283,19 @@ impl<K: Clone, V: Clone, S: Clone> Clone for FrozenMap<K, V, S> {
     }
 }
 
+impl<K: Eq + Hash, V: PartialEq + StableDeref> PartialEq for FrozenMap<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        assert!(!self.in_use.get());
+        assert!(!other.in_use.get());
+        self.in_use.set(true);
+        other.in_use.set(true);
+        let ret = self.map.get() == other.map.get();
+        self.in_use.set(false);
+        other.in_use.set(false);
+        ret
+    }
+}
+
 /// Append-only version of `std::collections::BTreeMap` where
 /// insertion does not require mutable access
 pub struct FrozenBTreeMap<K, V> {
@@ -522,7 +535,7 @@ impl<K: Clone, V: Clone> Clone for FrozenBTreeMap<K, V> {
     }
 }
 
-impl<K: Eq + Hash, V: PartialEq + StableDeref> PartialEq for FrozenMap<K, V> {
+impl<K: Eq + Hash, V: PartialEq + StableDeref> PartialEq for FrozenBTreeMap<K, V> {
     fn eq(&self, other: &Self) -> bool {
         assert!(!self.in_use.get());
         assert!(!other.in_use.get());

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -283,12 +283,12 @@ impl<'a, T: StableDeref> IntoIterator for &'a FrozenVec<T> {
     }
 }
 
-impl<T: StableDeref> PartialEq for FrozenVec<T>
+impl<T: StableDeref + PartialEq> PartialEq for FrozenVec<T>
 where
     T::Target: PartialEq,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.vec.get() == other.vec.get()
+        unsafe { self.vec.get().as_ref() == other.vec.get().as_ref() }
     }
 }
 


### PR DESCRIPTION
Previously the pointers were being compared, which is not what `PartialEq` should do.  This fixes the issue by dereferencing the maps and vectors before comparing them.

It also adds the missing impl for FrozenBTreeMap, which was missed during conflict fixes. 