### PR TITLE
Address clippy lints

### DIFF
--- a/examples/arena.rs
+++ b/examples/arena.rs
@@ -52,5 +52,5 @@ impl<'arena> Arena<'arena> {
 }
 
 fn cmp_ref<T>(x: &T, y: &T) -> bool {
-    x as *const T as usize == y as *const T as usize
+    std::ptr::eq(x, y)
 }

--- a/examples/fluentresource.rs
+++ b/examples/fluentresource.rs
@@ -9,12 +9,17 @@ impl<'mgr> FluentResource<'mgr> {
         // very simple parse step
         FluentResource(&s[0..1])
     }
+
+    pub fn get(&self) -> &'mgr str {
+        self.0
+    }
 }
 
 /// Stores loaded files and parsed ASTs
 ///
 /// Parsed ASTs are zero-copy and
 /// contain references to the files
+#[derive(Default)]
 pub struct ResourceManager<'mgr> {
     strings: FrozenMap<String, String>,
     resources: FrozenMap<String, Box<FluentResource<'mgr>>>,
@@ -22,10 +27,7 @@ pub struct ResourceManager<'mgr> {
 
 impl<'mgr> ResourceManager<'mgr> {
     pub fn new() -> Self {
-        ResourceManager {
-            strings: FrozenMap::new(),
-            resources: FrozenMap::new(),
-        }
+        Self::default()
     }
 
     pub fn get_resource(&'mgr self, path: &str) -> &'mgr FluentResource<'mgr> {
@@ -46,5 +48,6 @@ impl<'mgr> ResourceManager<'mgr> {
 fn main() {
     let manager = ResourceManager::new();
     let resource = manager.get_resource("somefile.ftl");
-    println!("{:?}", resource);
+
+    assert_eq!(resource.get(), "f");
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "stable"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/src/map.rs
+++ b/src/map.rs
@@ -97,10 +97,10 @@ impl<K: Eq + Hash, V: StableDeref, S: BuildHasher> FrozenMap<K, V, S> {
     /// assert_eq!(map.get(&1), Some(&"a"));
     /// assert_eq!(map.get(&2), None);
     /// ```
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V::Target>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V::Target>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         assert!(!self.in_use.get());
         self.in_use.set(true);
@@ -128,10 +128,10 @@ impl<K: Eq + Hash, V: StableDeref, S: BuildHasher> FrozenMap<K, V, S> {
     /// assert_eq!(map.map_get(&1, Clone::clone), Some(Box::new("a")));
     /// assert_eq!(map.map_get(&2, Clone::clone), None);
     /// ```
-    pub fn map_get<Q: ?Sized, T, F>(&self, k: &Q, f: F) -> Option<T>
+    pub fn map_get<Q, T, F>(&self, k: &Q, f: F) -> Option<T>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
         F: FnOnce(&V) -> T,
     {
         assert!(!self.in_use.get());
@@ -192,10 +192,10 @@ impl<K: Eq + Hash + StableDeref, V: StableDeref, S: BuildHasher> FrozenMap<K, V,
     /// assert_eq!(map.get_key_value(&"1"), Some((&"1", &"a")));
     /// assert_eq!(map.get_key_value(&"2"), None);
     /// ```
-    pub fn get_key_value<Q: ?Sized>(&self, k: &Q) -> Option<(&K::Target, &V::Target)>
+    pub fn get_key_value<Q>(&self, k: &Q) -> Option<(&K::Target, &V::Target)>
     where
         K: Borrow<Q>,
-        Q: Hash + Eq,
+        Q: Hash + Eq + ?Sized,
     {
         assert!(!self.in_use.get());
         self.in_use.set(true);
@@ -279,7 +279,7 @@ impl<K: Clone, V: Clone, S: Clone> Clone for FrozenMap<K, V, S> {
             in_use: Cell::from(false),
         };
         self.in_use.set(false);
-        return self_clone;
+        self_clone
     }
 }
 
@@ -384,10 +384,10 @@ impl<K: Clone + Ord, V: StableDeref> FrozenBTreeMap<K, V> {
     /// assert_eq!(map.get(&1), Some(&"a"));
     /// assert_eq!(map.get(&2), None);
     /// ```
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V::Target>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V::Target>
     where
         K: Borrow<Q>,
-        Q: Ord,
+        Q: Ord + ?Sized,
     {
         assert!(!self.in_use.get());
         self.in_use.set(true);
@@ -415,10 +415,10 @@ impl<K: Clone + Ord, V: StableDeref> FrozenBTreeMap<K, V> {
     /// assert_eq!(map.map_get(&1, Clone::clone), Some(Box::new("a")));
     /// assert_eq!(map.map_get(&2, Clone::clone), None);
     /// ```
-    pub fn map_get<Q: ?Sized, T, F>(&self, k: &Q, f: F) -> Option<T>
+    pub fn map_get<Q, T, F>(&self, k: &Q, f: F) -> Option<T>
     where
         K: Borrow<Q>,
-        Q: Ord,
+        Q: Ord + ?Sized,
         F: FnOnce(&V) -> T,
     {
         assert!(!self.in_use.get());
@@ -531,7 +531,7 @@ impl<K: Clone, V: Clone> Clone for FrozenBTreeMap<K, V> {
             in_use: Cell::from(false),
         };
         self.in_use.set(false);
-        return self_clone;
+        self_clone
     }
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -704,7 +704,7 @@ impl<T: Copy> Default for LockFreeFrozenVec<T> {
     /// any heap allocations until the first time data is pushed to it.
     fn default() -> Self {
         Self {
-            data: [const { Self::null() }; NUM_BUFFERS],
+            data: Self::null(),
             len: AtomicUsize::new(0),
             locked: AtomicBool::new(false),
         }
@@ -712,8 +712,8 @@ impl<T: Copy> Default for LockFreeFrozenVec<T> {
 }
 
 impl<T: Copy> LockFreeFrozenVec<T> {
-    const fn null() -> AtomicPtr<T> {
-        AtomicPtr::new(std::ptr::null_mut())
+    const fn null() -> [AtomicPtr<T>; NUM_BUFFERS] {
+        [const { AtomicPtr::new(std::ptr::null_mut()) }; NUM_BUFFERS]
     }
 
     pub fn new() -> Self {
@@ -910,7 +910,7 @@ fn test_non_lockfree_unchecked() {
 
 impl<T: Copy + Clone> Clone for LockFreeFrozenVec<T> {
     fn clone(&self) -> Self {
-        let mut coppied_data = [const { Self::null() }; NUM_BUFFERS];
+        let mut coppied_data = Self::null();
         // for each buffer, copy the data
         self.for_each_buffer(|buffer_slice, buffer_index| {
             // allocate a new buffer

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -62,7 +62,7 @@ impl<T: StableDeref> FrozenVec<T> {
     /// `index` must be in bounds, i.e. it must be less than `self.len()`
     pub unsafe fn get_unchecked(&self, index: usize) -> &T::Target {
         let vec = self.vec.get();
-        &**(*vec).get_unchecked(index)
+        (*vec).get_unchecked(index)
     }
 }
 
@@ -309,7 +309,7 @@ fn test_iteration() {
 fn test_accessors() {
     let vec: FrozenVec<String> = FrozenVec::new();
 
-    assert_eq!(vec.is_empty(), true);
+    assert!(vec.is_empty());
     assert_eq!(vec.len(), 0);
     assert_eq!(vec.first(), None);
     assert_eq!(vec.last(), None);
@@ -319,7 +319,7 @@ fn test_accessors() {
     vec.push("b".to_string());
     vec.push("c".to_string());
 
-    assert_eq!(vec.is_empty(), false);
+    assert!(!vec.is_empty());
     assert_eq!(vec.len(), 3);
     assert_eq!(vec.first(), Some("a"));
     assert_eq!(vec.last(), Some("c"));
@@ -332,7 +332,7 @@ fn test_non_stable_deref() {
     struct Moo(i32);
     let vec: FrozenVec<Moo> = FrozenVec::new();
 
-    assert_eq!(vec.is_empty(), true);
+    assert!(vec.is_empty());
     assert_eq!(vec.len(), 0);
     assert_eq!(vec.get_copy(1), None);
 
@@ -340,7 +340,7 @@ fn test_non_stable_deref() {
     vec.push(Moo(2));
     vec.push(Moo(3));
 
-    assert_eq!(vec.is_empty(), false);
+    assert!(!vec.is_empty());
     assert_eq!(vec.len(), 3);
     assert_eq!(vec.get_copy(1), Some(Moo(2)));
 }


### PR DESCRIPTION
Clippy threw some lints, so I just fixed them. In most cases, this was pretty straightforward. One lint was a little more involved: in `LockFreeFrozenVec`, I added a `// ## Safety` comment that mirrored the comments elsewhere in the codebase:

```rust
/// Load an element (if it exists). This operation is lock-free and
/// performs no synchronized atomic operations. This is a useful primitive to
/// implement your own data structure with newtypes around the index.
///
/// ## Safety
///
/// `index` must be in bounds, i.e. it must be less than `self.len()`
#[inline]
pub unsafe fn get_unchecked(&self, index: usize) -> T {
    let buffer_idx = buffer_index(index);
    let buffer_ptr = self.data[buffer_idx].load(Ordering::Relaxed);
    let local_index = index - prior_total_buffer_size(buffer_idx);
    unsafe { *buffer_ptr.add(local_index) }
}
```

However, a `LockFreeFrozenVec::len` method didn't exist, so I wrapped the existing calls to `self.len.load(Ordering::Acquire)`:

```rust
#[inline(always)]
pub fn len(&self) -> usize {
    self.len.load(Ordering::Acquire)
}
```

This modified the code in `LockFreeFrozenVec::is_empty`, which previously used `Ordering::Relaxed`. However, since stores always use `Ordering::Release`, [there is no visible behavior change](https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html#variant.Acquire).
