### PR TITLE
Fixed lockfree frozen vec being too small.

### DIFF
--- a/src/index_map.rs
+++ b/src/index_map.rs
@@ -90,7 +90,7 @@ impl<K: Eq + Hash, V: StableDeref, S: BuildHasher> FrozenIndexMap<K, V, S> {
     }
 
     /// Returns a reference to the value corresponding to the key.
-    /// 
+    ///
     /// # Arguments
     /// * `k` may be any type that implements [`Equivalent<K>`].
     ///
@@ -119,7 +119,7 @@ impl<K: Eq + Hash, V: StableDeref, S: BuildHasher> FrozenIndexMap<K, V, S> {
     }
 
     /// Returns the index corresponding to the key
-    /// 
+    ///
     /// # Arguments
     /// * `k` may be any type that implements [`Equivalent<K>`].
     ///
@@ -175,7 +175,7 @@ impl<K: Eq + Hash, V: StableDeref, S: BuildHasher> FrozenIndexMap<K, V, S> {
     }
 
     /// Returns a reference to the key, along with its index and a reference to its value
-    /// 
+    ///
     /// # Arguments
     /// * `k` may be any type that implements [`Equivalent<K>`].
     ///

--- a/src/index_set.rs
+++ b/src/index_set.rs
@@ -117,7 +117,7 @@ impl<T: Eq + Hash + StableDeref, S: BuildHasher> FrozenIndexSet<T, S> {
     // }
 
     /// Returns a reference to the value passed as argument if present in the set.
-    /// 
+    ///
     /// # Arguments
     /// * `k` may be any type that implements [`Equivalent<T>`].
     ///
@@ -146,10 +146,10 @@ impl<T: Eq + Hash + StableDeref, S: BuildHasher> FrozenIndexSet<T, S> {
     }
 
     /// Returns the index corresponding to the value if present in the set
-    /// 
+    ///
     /// # Arguments
     /// * `k` may be any type that implements [`Equivalent<T>`].
-    /// 
+    ///
     /// # Examples
     ///
     /// ```
@@ -176,7 +176,7 @@ impl<T: Eq + Hash + StableDeref, S: BuildHasher> FrozenIndexSet<T, S> {
 
     /// Returns a reference to the value passed as argument if present in the set,
     /// along with its index
-    /// 
+    ///
     /// # Arguments
     /// * `k` may be any type that implements [`Equivalent<T>`].
     ///

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -665,13 +665,15 @@ const fn buffer_index(i: usize) -> usize {
     (((usize::BITS + 1 - (i + 1).leading_zeros()) >> 1) - 1) as usize
 }
 
-const NUM_BUFFERS: usize = (usize::BITS >> 2) as usize;
+/// Each buffer covers 2 bits of address space, so we need half as many
+/// buffers as bits in a usize.
+const NUM_BUFFERS: usize = (usize::BITS / 2) as usize;
 
 /// Append-only threadsafe version of `std::vec::Vec` where
 /// insertion does not require mutable access.
 /// Does not lock for reading, only allows `Copy` types and
 /// will spinlock on pushes without affecting reads.
-/// Note that this data structure is `64` pointers large on
+/// Note that this data structure is `34` pointers large on
 /// 64 bit systems,
 /// in contrast to `Vec` which is `3` pointers large.
 pub struct LockFreeFrozenVec<T: Copy> {


### PR DESCRIPTION
The current implementation accidently divides by 4 instead of 2 when calculating the number of buffers required. This means that on 32 bit systems only 65535 items can be in a `LockFreeFrozenVec`, which the rust compiler exceeds. (See also https://github.com/rust-lang-ci/rust/actions/runs/12980407836/job/36197397174, triggered by https://github.com/rust-lang/rust/pull/136094)

Is it possible to release a new version after this bugfix has been merged?