### PR TITLE
Make Vec and BTreeMap constructors const fns

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -311,9 +311,9 @@ pub struct FrozenBTreeMap<K, V> {
 // safety: UnsafeCell implies !Sync
 
 impl<K: Clone + Ord, V: StableDeref> FrozenBTreeMap<K, V> {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
-            map: UnsafeCell::new(Default::default()),
+            map: UnsafeCell::new(BTreeMap::new()),
             in_use: Cell::new(false),
         }
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -473,8 +473,10 @@ impl<T> FrozenVec<T> {
 }
 
 impl<T: StableDeref> FrozenVec<T> {
-    pub fn new() -> Self {
-        Default::default()
+    pub const fn new() -> Self {
+        Self {
+            vec: RwLock::new(Vec::new()),
+        }
     }
 
     // these should never return &T
@@ -703,11 +705,7 @@ impl<T: Copy> Default for LockFreeFrozenVec<T> {
     /// Creates an empty `LockFreeFrozenVec` that does not allocate
     /// any heap allocations until the first time data is pushed to it.
     fn default() -> Self {
-        Self {
-            data: Self::null(),
-            len: AtomicUsize::new(0),
-            locked: AtomicBool::new(false),
-        }
+        Self::new()
     }
 }
 
@@ -716,8 +714,12 @@ impl<T: Copy> LockFreeFrozenVec<T> {
         [const { AtomicPtr::new(std::ptr::null_mut()) }; NUM_BUFFERS]
     }
 
-    pub fn new() -> Self {
-        Default::default()
+    pub const fn new() -> Self {
+        Self {
+            data: Self::null(),
+            len: AtomicUsize::new(0),
+            locked: AtomicBool::new(false),
+        }
     }
 
     /// Obtains a write lock that ensures other writing threads
@@ -1007,7 +1009,7 @@ fn test_non_lockfree() {
 pub struct FrozenBTreeMap<K, V>(RwLock<BTreeMap<K, V>>);
 
 impl<K: Clone + Ord, V: StableDeref> FrozenBTreeMap<K, V> {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self(RwLock::new(BTreeMap::new()))
     }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -17,9 +17,9 @@ pub struct FrozenVec<T> {
 
 impl<T> FrozenVec<T> {
     /// Constructs a new, empty vector.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
-            vec: UnsafeCell::new(Default::default()),
+            vec: UnsafeCell::new(Vec::new()),
         }
     }
 }


### PR DESCRIPTION
This is especially useful for the `sync` ones, since this means you can use them as a `static` directly (no wrapping in `LazyLock`).