### PR TITLE
Fix #83: Remove Usage of `inline-const` Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elsa"
-version = "1.11.0"
+version = "1.11.1"
 authors = ["Manish Goregaokar <manishsmail@gmail.com>"]
 edition = "2018"
 description = "Append-only collections for Rust where borrows to entries can outlive insertions"

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -712,8 +712,10 @@ impl<T: Copy> Default for LockFreeFrozenVec<T> {
 }
 
 impl<T: Copy> LockFreeFrozenVec<T> {
+    const NULL_ATOMIC_PTR: AtomicPtr<T> = AtomicPtr::new(std::ptr::null_mut());
+
     const fn null() -> [AtomicPtr<T>; NUM_BUFFERS] {
-        [const { AtomicPtr::new(std::ptr::null_mut()) }; NUM_BUFFERS]
+        [Self::NULL_ATOMIC_PTR; NUM_BUFFERS]
     }
 
     pub const fn new() -> Self {


### PR DESCRIPTION
Fix #83 by introducing an intermediate constant and bump version to 0.11.1, tested against `nightly-2023-05-27`.