### PR TITLE
fix dangerous_implicit_deref lint

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -43,7 +43,7 @@ impl<T: StableDeref> FrozenVec<T> {
         unsafe {
             let vec = self.vec.get();
             (*vec).push(val);
-            &*(&**(*vec).get_unchecked((*vec).len() - 1) as *const T::Target)
+            &*(&**(&*vec).get_unchecked((*vec).len() - 1) as *const T::Target)
         }
     }
 
@@ -51,7 +51,7 @@ impl<T: StableDeref> FrozenVec<T> {
     pub fn get(&self, index: usize) -> Option<&T::Target> {
         unsafe {
             let vec = self.vec.get();
-            (*vec).get(index).map(|x| &**x)
+            (&*vec).get(index).map(|x| &**x)
         }
     }
 
@@ -62,7 +62,7 @@ impl<T: StableDeref> FrozenVec<T> {
     /// `index` must be in bounds, i.e. it must be less than `self.len()`
     pub unsafe fn get_unchecked(&self, index: usize) -> &T::Target {
         let vec = self.vec.get();
-        (*vec).get_unchecked(index)
+        (&*vec).get_unchecked(index)
     }
 }
 
@@ -71,7 +71,7 @@ impl<T: Copy> FrozenVec<T> {
     pub fn get_copy(&self, index: usize) -> Option<T> {
         unsafe {
             let vec = self.vec.get();
-            (*vec).get(index).copied()
+            (&*vec).get(index).copied()
         }
     }
 }
@@ -108,7 +108,7 @@ impl<T: StableDeref> FrozenVec<T> {
         }
     }
     /// Returns an iterator over the vector.
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         self.into_iter()
     }
 }
@@ -316,6 +316,9 @@ fn test_accessors() {
     assert_eq!(vec.get(1), None);
 
     vec.push("a".to_string());
+
+    let item = vec.first().unwrap();
+
     vec.push("b".to_string());
     vec.push("c".to_string());
 
@@ -324,6 +327,8 @@ fn test_accessors() {
     assert_eq!(vec.first(), Some("a"));
     assert_eq!(vec.last(), Some("c"));
     assert_eq!(vec.get(1), Some("b"));
+
+    assert_eq!(item, "a");
 }
 
 #[test]


### PR DESCRIPTION
The lint got upgraded to deny_by_default in the latest `beta`. These changes change no behaviour but make the reference creation visible.