### PR TITLE
fix: remove `StableDeref` bound from `into_vec`

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -120,7 +120,7 @@ impl<T: StableDeref> FrozenVec<T> {
     }
 }
 
-impl<T: StableDeref> FrozenVec<T> {
+impl<T> FrozenVec<T> {
     /// Converts the frozen vector into a plain vector.
     pub fn into_vec(self) -> Vec<T> {
         self.vec.into_inner()


### PR DESCRIPTION
Fixes #79
